### PR TITLE
Fix cambio a orbe de peso.

### DIFF
--- a/Assets/Sandbox/Scripts/Orbs/OrbLauncher.cs
+++ b/Assets/Sandbox/Scripts/Orbs/OrbLauncher.cs
@@ -148,9 +148,11 @@ public class OrbLauncher : MonoBehaviour
     }
 
     private void ChangeOrbWeigth(){
-        Debug.Log("Cambio de peso");
-        _augmentWeigthOrb = !_augmentWeigthOrb;
-        changeAugmentText();
+        if(_selectedOrb.GetComponent<WeigthOrb>() != null){
+            Debug.Log("Cambio de peso");
+            _augmentWeigthOrb = !_augmentWeigthOrb;
+            changeAugmentText();
+        } 
     }
 
     private void changeOrbText(){


### PR DESCRIPTION
El método que cambia el tipo de gravedad del orbe ahora está solo activo cuando el orbe está en pesado.